### PR TITLE
Fix typo

### DIFF
--- a/net.jeeeyul.pdetools/plugin.xml
+++ b/net.jeeeyul.pdetools/plugin.xml
@@ -1031,7 +1031,7 @@
    </extension>
    <extension
          id="net.jeeeyul.pdetoos.java.proposal"
-         name="PDE-Tools Java Sematics Proposal"
+         name="PDE-Tools Java Semantics Proposals"
          point="org.eclipse.jdt.ui.javaCompletionProposalComputer">
       <proposalCategory
             icon="icons/plugins.gif">


### PR DESCRIPTION
Semantics misses an "n". Also use plural for "Proposals", since every other proposal computer uses plural in the title.
Ids and class names with similar issues have been left unchanged to avoid huge refactorings.